### PR TITLE
modified CMAKELists to build examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,3 +431,4 @@ endif()
 
 # Include CPack
 include(CPack)
+add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -27,10 +27,10 @@ message(STATUS "SOFTPOSIT_LIBRARIES: ${SOFTPOSIT_LIBRARIES}")
 message(STATUS "SOFTPOSIT_SHARED_LIBRARIES: ${SOFTPOSIT_SHARED_LIBRARIES}")
 
 # Check if the include directory exists
-if(NOT EXISTS "${SOFTPOSIT_INCLUDE_DIRS}")
-  message(FATAL_ERROR "SoftPosit include directory not found: ${SOFTPOSIT_INCLUDE_DIRS}\n"
-                     "Please specify -DCMAKE_PREFIX_PATH=<path-to-softposit-install>")
-endif()
+# if(NOT EXISTS "${SOFTPOSIT_INCLUDE_DIRS}")
+#   message(FATAL_ERROR "SoftPosit include directory not found: ${SOFTPOSIT_INCLUDE_DIRS}\n"
+#                      "Please specify -DCMAKE_PREFIX_PATH=<path-to-softposit-install>")
+# endif()
 
 # Try to use find_package first, fall back to direct paths if it fails
 find_package(SoftPosit QUIET)


### PR DESCRIPTION
## Problem:
Running 
```bash
mkdir -p build
cd build
cmake .. -DCMAKE_PREFIX_PATH=../../install
make
```

doesn't build the examples.

## Fix
Added 
```c
add_subdirectory(examples)
```
to the CMakeLists.txt in the root directory