### PR TITLE
don't print anything by default in library

### DIFF
--- a/src/p32_to_p16.c
+++ b/src/p32_to_p16.c
@@ -97,8 +97,8 @@ posit16_t p32_to_p16(posit32_t pA)
         }
         // exp and frac
         exp_frac32A = tmp << 1;
-        printBinary(&exp_frac32A, 32);
-        printf("kA: %d\n", kA);
+        //printBinary(&exp_frac32A, 32);
+        //printf("kA: %d\n", kA);
         if (kA < 0)
         {
             regA = (-kA) << 1;
@@ -135,3 +135,4 @@ posit16_t p32_to_p16(posit32_t pA)
         uZ.ui = (-uZ.ui & 0xFFFF);
     return uZ.p;
 }
+

--- a/src/ui64_to_pX1.c
+++ b/src/ui64_to_pX1.c
@@ -64,8 +64,8 @@ posit_1_t ui64_to_pX1(uint64_t a, int x)
     }
     else if (a > 0x8000000000000000)
     {  // 576460752303423488 -> wrong number need to change
-        uint64_t test = ((uint64_t) 0x80000000 >> (x - 1));
-        printBinary(&test, 32);
+        //uint64_t test = ((uint64_t) 0x80000000 >> (x - 1));
+        //printBinary(&test, 32);
         uiA = 0x7FFFFFFF & ((uint64_t) 0x80000000 >> (x - 1));  // 1152921504606847000
     }
     else if (a < 0x2)
@@ -137,3 +137,4 @@ posit_1_t ui64_to_pX1(uint64_t a, int x)
     uZ.ui = uiA;
     return uZ.p;
 }
+


### PR DESCRIPTION
If it's meant to be a debug, then it should be replaced with some kind of debug_print() which would be enabled in debug mode.